### PR TITLE
feat/post-api

### DIFF
--- a/server/src/routes/post-route.ts
+++ b/server/src/routes/post-route.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { verifyJWT } from '../middleware/auth-middleware';
 import { uploadFilesMiddleware } from '../middleware/upload-middleware';
-import { createNewPost } from '../controllers/post-controllers';
+import { createNewPost, deletePost, editPost } from '../controllers/post-controllers';
 
 
 const post_router = Router();
@@ -9,5 +9,5 @@ const post_router = Router();
 
 
 post_router.route('/create-new-post').post(verifyJWT, uploadFilesMiddleware, createNewPost);
-
-export default post_router;  
+post_router.route('/edit-post/:postId').put(verifyJWT, uploadFilesMiddleware, editPost);
+post_router.route('/delete-post/:postId').delete(verifyJWT, deletePost);


### PR DESCRIPTION
## Description

This pull request adds a new POST API endpoint `delete/api/posts`  `edit/api/posts`  to the server. The endpoint allows clients to create a new post by sending a JSON payload containing a title, body, and optional author field. The data is validated and stored in MongoDB using Mongoose. This feature enhances the backend functionality by allowing new content creation.

## Type of Change

- [x] New feature

## How Has This Been Tested?

- Tested using Postman to ensure valid data is successfully stored in the database.
- Verified that:
  - A 201 response is returned upon successful post creation.
  - A 400 response is returned if required fields are missing.
  - A 500 response is returned if a server error occurs.


